### PR TITLE
Merge branch 'release-0.9.2' into production

### DIFF
--- a/data/fqdn/seed.raft.com.yaml
+++ b/data/fqdn/seed.raft.com.yaml
@@ -44,7 +44,7 @@ profiles::dhcp::pools:
 profiles::disk::mounts:
   'debian_iso9660_local':
     name: '/media/cdrom'
-    device: 'LABEL=Debian\04011.3\040amd64\0401'
+    device: 'LABEL=Debian\04011.5\040amd64\0401'
     ensure: mounted
     fstype: 'iso9660'
     options: 'ro,x-mount.mkdir'

--- a/data/fqdn/seed.raft.com.yaml
+++ b/data/fqdn/seed.raft.com.yaml
@@ -6,8 +6,8 @@ profiles::apt::purge:
   'preferences.list.d': true
 
 profiles::apt::sources:
-  'debian_buster_local':
-    comment: 'Complete, static, local Debian buster (11.3) mirror'
+  'debian_bullseye_local':
+    comment: 'Complete, static, local Debian bullseye (11.5) mirror'
     location: 'file:/media/cdrom/mirror/'
     repos: 'main contrib non-free'
   'puppetlabs_local':

--- a/data/fqdn/seed.raft.com.yaml
+++ b/data/fqdn/seed.raft.com.yaml
@@ -13,7 +13,7 @@ profiles::apt::sources:
   'puppetlabs_local':
     comment: 'Puppetlabs 7.X Debian GNU/Linux bullseye repository'
     location: 'file:/media/cdrom/extra/mirror/puppetlabs/bullseye/'
-    repos: 'bullseye puppet7'
+    repos: 'puppet7'
 
 profiles::dhcp::service_ensure: 'running'
 profiles::dhcp::interfaces:

--- a/site/profiles/metadata.json
+++ b/site/profiles/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "penguinspiral-profiles",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "grindon",
   "summary": "Roles & Profiles pattern",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
### Puppet Agent Test (noop)
```
debian@seed:/etc/puppetlabs/code/environments$ sudo /opt/puppetlabs/bin/puppet agent --test --noop --environment=release_0_9_2
Info: Using environment 'release_0_9_2'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Applying configuration version '1667034309'
Notice: /Stage[main]/Apt/File[/etc/apt/sources.list.d/debian_buster_local.list]/ensure: current_value 'file', should be 'absent' (noop)
Notice: sources.list.d: Would have triggered 'refresh' from 1 event
Info: sources.list.d: Scheduling refresh of Class[Apt::Update]
Notice: /Stage[main]/Profiles::Disk/Mount[debian_iso9660_local]/device: current_value 'LABEL=Debian 11.3 amd64 1', should be 'LABEL=Debian\04011.5\040amd64\0401' (noop) (corrective)
Info: /Stage[main]/Profiles::Disk/Mount[debian_iso9660_local]: Scheduling refresh of Mount[debian_iso9660_local]
Notice: /Stage[main]/Profiles::Disk/Mount[debian_iso9660_local]: Would have triggered 'refresh' from 1 event
Info: /Stage[main]/Profiles::Disk/Mount[debian_iso9660_local]: Scheduling refresh of Mount[debian_iso9660_local]
Notice: Class[Profiles::Disk]: Would have triggered 'refresh' from 2 events
Notice: /Stage[main]/Apt/Apt::Source[debian_bullseye_local]/Apt::Setting[list-debian_bullseye_local]/File[/etc/apt/sources.list.d/debian_bullseye_local.list]/ensure: current_value 'absent', should be 'present' (noop)
Info: /Stage[main]/Apt/Apt::Source[debian_bullseye_local]/Apt::Setting[list-debian_bullseye_local]/File[/etc/apt/sources.list.d/debian_bullseye_local.list]: Scheduling refresh of Class[Apt::Update]
Notice: Apt::Setting[list-debian_bullseye_local]: Would have triggered 'refresh' from 1 event
Notice: Apt::Source[debian_bullseye_local]: Would have triggered 'refresh' from 1 event
Notice: /Stage[main]/Apt/Apt::Source[puppetlabs_local]/Apt::Setting[list-puppetlabs_local]/File[/etc/apt/sources.list.d/puppetlabs_local.list]/content: 
--- /etc/apt/sources.list.d/puppetlabs_local.list	2022-10-28 02:11:55.388188144 -0700
+++ /tmp/puppet-file20221029-12770-lcw8c5	2022-10-29 02:05:16.711672042 -0700
@@ -1,3 +1,3 @@
 # This file is managed by Puppet. DO NOT EDIT.
 # Puppetlabs 7.X Debian GNU/Linux bullseye repository
-deb file:/media/cdrom/extra/mirror/puppetlabs/bullseye/ bullseye bullseye puppet7
+deb file:/media/cdrom/extra/mirror/puppetlabs/bullseye/ bullseye puppet7

Notice: /Stage[main]/Apt/Apt::Source[puppetlabs_local]/Apt::Setting[list-puppetlabs_local]/File[/etc/apt/sources.list.d/puppetlabs_local.list]/content: current_value '{sha256}1291ed67ba2a6844c3bf26974490ae4fed5a9eafbc48c994dd4fffbe5968d48c', should be '{sha256}958c94dbde1ffefacc48b3b1ecb3167332ee9cfd52882c96c89a093674217e85' (noop)
Info: /Stage[main]/Apt/Apt::Source[puppetlabs_local]/Apt::Setting[list-puppetlabs_local]/File[/etc/apt/sources.list.d/puppetlabs_local.list]: Scheduling refresh of Class[Apt::Update]
Notice: Class[Apt::Update]: Would have triggered 'refresh' from 3 events
Info: Class[Apt::Update]: Scheduling refresh of Exec[apt_update]
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Would have triggered 'refresh' from 1 event
Notice: Class[Apt::Update]: Would have triggered 'refresh' from 1 event
Notice: Apt::Setting[list-puppetlabs_local]: Would have triggered 'refresh' from 1 event
Notice: Apt::Source[puppetlabs_local]: Would have triggered 'refresh' from 1 event
Notice: Class[Apt]: Would have triggered 'refresh' from 3 events
Notice: Stage[main]: Would have triggered 'refresh' from 3 events
Notice: Applied catalog in 1.56 seconds
```